### PR TITLE
Make concatenated query_df a Dataframe not a tuple

### DIFF
--- a/src/ebm4subjects/ebm_model.py
+++ b/src/ebm4subjects/ebm_model.py
@@ -408,7 +408,7 @@ class EbmModel:
             )
             id_count += len(chunks)
 
-        query_df = (pl.concat(query_dfs),)
+        query_df = pl.concat(query_dfs)
 
         self.logger.info("Running verctor search and creating candidates")
         candidates = self.client.vector_search(


### PR DESCRIPTION
Es gab einen Fehler in dieser [Zeile](https://github.com/deutsche-nationalbibliothek/ebm4subjects/blob/d3418042e985f00408cec778cc0f60d26153654d/src/ebm4subjects/duckdb_client.py#L68), wenn sie von der `generate_candidates_batch` Methode aufgerufen wurde. Ich glaube das Problem war, dass hier ein Tuple erstellt wurde und kein Dataframe, aber dann später das Dataframe-Attribut height abgefragt wurde. 

Vielleicht übersehe ich, warum es doch ein Tuple sein sollte. 
Wenn nicht, dann gern mergen. 