### PR TITLE
Fix typos in Python code

### DIFF
--- a/src/ebm4subjects/analyzer.py
+++ b/src/ebm4subjects/analyzer.py
@@ -51,7 +51,7 @@ class EbmAnalyzer:
         Returns:
             list[str]: A list of tokenized sentences.
         """
-        # Replace multiple periods by a singel one
+        # Replace multiple periods by a single one
         # Necessary to work properly with some tables of contents
         text = re.sub(r"\.{4,}", ". ", str(text))
         # Tokenize the text and return it

--- a/src/ebm4subjects/chunker.py
+++ b/src/ebm4subjects/chunker.py
@@ -134,7 +134,7 @@ class Chunker:
             text_chunks.extend(batch_chunks)
             chunk_index.extend(batch_chunk_indices)
 
-        # Return the chunked texts and coressponding chunk indices
+        # Return the chunked texts and corresponding chunk indices
         return text_chunks, chunk_index
 
     def _chunk_batch(self, args) -> Tuple[list[str], list[pl.DataFrame]]:

--- a/src/ebm4subjects/duckdb_client.py
+++ b/src/ebm4subjects/duckdb_client.py
@@ -233,14 +233,14 @@ class Duckdb_client:
         )
 
         # Across chunks (queries) aggregate statistics for
-        # each tupel 'doc_id', 'label_id'
+        # each tuple 'doc_id', 'label_id'
         result_df = result_df.group_by(["doc_id", "label_id"]).agg(
             score=pl.col("score").sum(),
             occurrences=pl.col("doc_id").count(),
             min_cosine_similarity=pl.col("cosine_similarity").min(),
             max_cosine_similarity=pl.col("cosine_similarity").max(),
-            first_occurence=pl.col("chunk_position").min(),
-            last_occurence=pl.col("chunk_position").max(),
+            first_occurrence=pl.col("chunk_position").min(),
+            last_occurrence=pl.col("chunk_position").max(),
             spread=(pl.col("chunk_position").max() - pl.col("chunk_position").min()),
             is_prefLabel=pl.col("is_prefLabel").first(),
             n_chunks=pl.col("n_chunks").first(),
@@ -255,8 +255,8 @@ class Duckdb_client:
         return result_df.with_columns(
             (pl.col("score") / pl.col("n_chunks")),
             (pl.col("occurrences") / pl.col("n_chunks")),
-            (pl.col("first_occurence") / pl.col("n_chunks")),
-            (pl.col("last_occurence") / pl.col("n_chunks")),
+            (pl.col("first_occurrence") / pl.col("n_chunks")),
+            (pl.col("last_occurrence") / pl.col("n_chunks")),
             (pl.col("spread") / pl.col("n_chunks")),
         ).sort(["doc_id", "label_id"])
 

--- a/src/ebm4subjects/ebm_model.py
+++ b/src/ebm4subjects/ebm_model.py
@@ -139,7 +139,7 @@ class EbmModel:
         self.train_rounds = int(xgb_rounds)
         self.train_jobs = int(xgb_jobs)
 
-        # Initiliaze logging
+        # Initialize logging
         self.init_logger(log_path, logger, logging_level)
 
         # Initialize EBM model
@@ -150,7 +150,7 @@ class EbmModel:
         Initializes the DuckDB client if it does not already exist.
 
         This method creates a new DuckDB client if it is not already
-        initiliazed and configures it with the provided database path,
+        initializes and configures it with the provided database path,
         thread settings, and HNSW index parameters.
 
         Returns:
@@ -379,8 +379,8 @@ class EbmModel:
                     "occurrences",
                     "min_cosine_similarity",
                     "max_cosine_similarity",
-                    "first_occurence",
-                    "last_occurence",
+                    "first_occurrence",
+                    "last_occurrence",
                     "spread",
                     "is_prefLabel",
                     "n_chunks",
@@ -445,7 +445,7 @@ class EbmModel:
             text (str): The input text.
             doc_id (int): The document ID.
             n_jobs (int, optional): The number of jobs to use for parallel
-                rocessing (default: 0).
+                processing (default: 0).
 
         Returns:
             pl.DataFrame: A DataFrame containing the generated candidate labels.
@@ -532,8 +532,8 @@ class EbmModel:
                     "occurrences": pl.Float64,
                     "min_cosine_similarity": pl.Float64,
                     "max_cosine_similarity": pl.Float64,
-                    "first_occurence": pl.Float64,
-                    "last_occurence": pl.Float64,
+                    "first_occurrence": pl.Float64,
+                    "last_occurrence": pl.Float64,
                     "spread": pl.Float64,
                     "is_prefLabel": pl.Boolean,
                     "n_chunks": pl.Int32,
@@ -545,8 +545,8 @@ class EbmModel:
                     "occurrences": None,
                     "min_cosine_similarity": None,
                     "max_cosine_similarity": None,
-                    "first_occurence": None,
-                    "last_occurence": None,
+                    "first_occurrence": None,
+                    "last_occurrence": None,
                     "spread": None,
                     "is_prefLabel": None,
                     "n_chunks": None,
@@ -646,8 +646,8 @@ class EbmModel:
                         "occurrences": None,
                         "min_cosine_similarity": None,
                         "max_cosine_similarity": None,
-                        "first_occurence": None,
-                        "last_occurence": None,
+                        "first_occurrence": None,
+                        "last_occurrence": None,
                         "spread": None,
                         "is_prefLabel": None,
                         "n_chunks": None,
@@ -688,8 +688,8 @@ class EbmModel:
                     "occurrences",
                     "min_cosine_similarity",
                     "max_cosine_similarity",
-                    "first_occurence",
-                    "last_occurence",
+                    "first_occurrence",
+                    "last_occurrence",
                     "spread",
                     "is_prefLabel",
                     "n_chunks",
@@ -763,8 +763,8 @@ class EbmModel:
                     "occurrences",
                     "min_cosine_similarity",
                     "max_cosine_similarity",
-                    "first_occurence",
-                    "last_occurence",
+                    "first_occurrence",
+                    "last_occurrence",
                     "spread",
                     "is_prefLabel",
                     "n_chunks",

--- a/src/ebm4subjects/embedding_generator.py
+++ b/src/ebm4subjects/embedding_generator.py
@@ -14,13 +14,13 @@ class EmbeddingGenerator:
 
     def __init__(self) -> None:
         """
-        Base method fot the initialization of an EmbeddingGenerator.
+        Base method for the initialization of an EmbeddingGenerator.
         """
         pass
 
     def generate_embeddings(self, texts: list[str], **kwargs) -> np.ndarray:
         """
-        Base method fot the creating embeddings with an EmbeddingGenerator.
+        Base method for the creating embeddings with an EmbeddingGenerator.
 
         Args:
             texts (list[str]): A list of input texts.
@@ -48,7 +48,7 @@ class EmbeddingGeneratorHuggingFaceTEI(EmbeddingGenerator):
         """
         Initializes the HuggingFaceTEI API EmbeddingGenerator.
 
-        Sets the embedding dimensions, and initiliazes and
+        Sets the embedding dimensions, and initializes and
         prepares a session with the API.
 
         Args:
@@ -117,7 +117,7 @@ class EmbeddingGeneratorHuggingFaceTEI(EmbeddingGenerator):
                 self.api_address, headers=self.headers, json=data
             )
 
-            # add generated embeddings to return list if request was successfull
+            # add generated embeddings to return list if request was successful
             if response.status_code == 200:
                 embeddings.extend(response.json())
             else:
@@ -143,7 +143,7 @@ class EmbeddingGeneratorOpenAI(EmbeddingGenerator):
         """
         Initializes the OpenAI API EmbeddingGenerator.
 
-        Sets the embedding dimensions, and initiliazes and
+        Sets the embedding dimensions, and initializes and
         prepares a session with the API.
 
         Args:
@@ -259,9 +259,9 @@ class EmbeddingGeneratorInProcess(EmbeddingGenerator):
             model_name, truncate_dim=embedding_dimensions, **kwargs
         )
         self.logger = logger
-        self.logger.debug(f"SentenceTransfomer model running on {self.model.device}")
+        self.logger.debug(f"SentenceTransformer model running on {self.model.device}")
 
-        # Disabel parallelism for tokenizer
+        # Disable parallelism for tokenizer
         # Needed because process might be already parallelized
         # before embedding creation
         os.environ["TOKENIZERS_PARALLELISM"] = "false"


### PR DESCRIPTION
This PR is a follow up of #10 ; it fixes typos in the Python code. Please review carefully, as I have also changed parameters e.g. `{first, last}_occurrence`.